### PR TITLE
Implement addEndListener prop

### DIFF
--- a/src/CSSTransition.ts
+++ b/src/CSSTransition.ts
@@ -1,4 +1,4 @@
-import { createElement, cloneElement, VNode } from 'preact'
+import { createElement, cloneElement, VNode, RefObject } from 'preact'
 import { useMemo } from 'preact/hooks'
 import Transition, { Phase, TransitionProps } from './Transition'
 
@@ -51,7 +51,7 @@ const computeClassName = (phase: Phase, classNames: CSSTransitionClassNames) => 
 
 export default (props: CSSTransitionProps): VNode<any> => {
   const { children, classNames, ...rest } = props
-  return createElement(Transition, rest, (state, phase: Phase) => {
+  return createElement(Transition, rest, (state, phase: Phase, ref: RefObject<Element>) => {
     const { className } = children.props
 
     const finalClassName = useMemo(() => (
@@ -60,6 +60,7 @@ export default (props: CSSTransitionProps): VNode<any> => {
 
     return cloneElement(children, {
       className: finalClassName,
+      ref,
     })
   })
 }

--- a/src/StyleTransition.ts
+++ b/src/StyleTransition.ts
@@ -1,4 +1,4 @@
-import { createElement, cloneElement, VNode } from 'preact'
+import { createElement, cloneElement, VNode, RefObject } from 'preact'
 import { useMemo } from 'preact/hooks'
 import Transition, { Phase, TransitionProps } from './Transition'
 
@@ -23,7 +23,7 @@ const computeStyle = (phase: Phase, styles: StyleTransitionStyles) => {
 
 export default (props: StyleTransitionProps): VNode<any> => {
   const { children, styles, ...rest } = props
-  return createElement(Transition, rest, (state, phase: Phase) => {
+  return createElement(Transition, rest, (state, phase: Phase, ref: RefObject<Element>) => {
     const { style } = children.props
 
     const finalStyle = useMemo(() => ({
@@ -32,6 +32,7 @@ export default (props: StyleTransitionProps): VNode<any> => {
 
     return cloneElement(children, {
       style: finalStyle,
+      ref,
     })
   })
 }


### PR DESCRIPTION
This PR implements functionality to detect animation ends without using duration. An example would be:

```js
<CSSTransition
  addEndListener={(node, done) => node.addEventListener('transitionend', done, { once: true, capture: false })}
  appear={true}
  in={visible}
>
  <div className='transition'>Bam</div>
</CSSTransition>


```