### PR TITLE
Let CSSTransition use the transitionend event if there is no duration.

### DIFF
--- a/src/CSSTransition.ts
+++ b/src/CSSTransition.ts
@@ -51,6 +51,19 @@ const computeClassName = (phase: Phase, classNames: CSSTransitionClassNames) => 
 
 export default (props: CSSTransitionProps): VNode<any> => {
   const { children, classNames, ...rest } = props;
+
+  if (!rest.duration) {
+    const addEndListener = rest.addEndListener;
+
+    rest.addEndListener = (node: Element, done: () => void) => {
+      if (addEndListener) {
+        addEndListener(node, done);
+      } else {
+        node.addEventListener("transitionend", done, { once: true });
+      }
+    };
+  }
+
   return createElement(Transition, rest, (state, phase: Phase) => {
     const { className } = children.props;
 


### PR DESCRIPTION
This reduces configuration and risk of skew between transitions and JavaScript.

https://developer.mozilla.org/en-US/docs/Web/API/Element/transitionend_event