### PR TITLE
Make CSSTransition use the "class" attribute if available.

### DIFF
--- a/src/CSSTransition.ts
+++ b/src/CSSTransition.ts
@@ -52,13 +52,18 @@ const computeClassName = (phase: Phase, classNames: CSSTransitionClassNames) => 
 export default (props: CSSTransitionProps): VNode<any> => {
   const { children, classNames, ...rest } = props;
   return createElement(Transition, rest, (state, phase: Phase) => {
-    const { className } = children.props;
+    const { className, class: cls } = children.props;
 
-    const finalClassName = useMemo(
-      () => joinClassNames(className, computeClassName(phase, classNames)),
-      [className, classNames, phase],
+    const finalProps = useMemo(
+      () => {
+        const propName = cls && !className ? 'class' : 'className';
+        const finalClassNames = joinClassNames(className ?? cls, computeClassName(phase, classNames));
+
+        return { [propName]: finalClassNames };
+      },
+      [className, cls, classNames, phase],
     );
 
-    return cloneElement(children, { className: finalClassName });
+    return cloneElement(children, finalProps);
   });
 };


### PR DESCRIPTION
Preact prefers the class attribute, but supports React's className.

https://preactjs.com/guide/v10/differences-to-react#raw-html-attributeproperty-names

Retains the existing behavior of using className by default.

Closes #50.