### PR TITLE
Fix typing of children to return VNode.

### DIFF
--- a/src/Transition.ts
+++ b/src/Transition.ts
@@ -44,7 +44,7 @@ export type TransitionState = {
 export type TransitionProps = {
   [key in PhaseEvent]?: (node?: Element) => void;
 } & {
-  children: (transitionState: TransitionState, activePhase: Phase) => any;
+  children: (transitionState: TransitionState, activePhase: Phase) => VNode<any>;
   in?: boolean;
   appear?: boolean;
   enter?: boolean;


### PR DESCRIPTION
Transition assumes there is a ref property on the returned object.